### PR TITLE
Explictly cast to get around 'pow' resolution ambiguity.

### DIFF
--- a/Source/WebCore/rendering/shapes/BoxShape.cpp
+++ b/Source/WebCore/rendering/shapes/BoxShape.cpp
@@ -43,7 +43,7 @@ static inline LayoutUnit adjustRadiusForMarginBoxShape(LayoutUnit radius, Layout
 
     LayoutUnit ratio = radius / margin;
     if (ratio < 1)
-        return radius + (margin * (1 + pow(ratio - 1, 3)));
+        return radius + (margin * (1 + pow((double)(ratio - 1), (double)(3))));
 
     return radius + margin;
 }


### PR DESCRIPTION
This resolves https://github.com/clbr/webkitfltk/issues/15.
