### PR TITLE
Change uppercase BOOLS to lowercase bools

### DIFF
--- a/Source/WebCore/platform/network/curl/ResourceHandleManager.cpp
+++ b/Source/WebCore/platform/network/curl/ResourceHandleManager.cpp
@@ -901,7 +901,7 @@ static void setupFormData(ResourceHandle* job, CURLoption sizeOption, struct cur
 void ResourceHandleManager::setupPUT(ResourceHandle* job, struct curl_slist** headers)
 {
     ResourceHandleInternal* d = job->getInternal();
-    curl_easy_setopt(d->m_handle, CURLOPT_UPLOAD, TRUE);
+    curl_easy_setopt(d->m_handle, CURLOPT_UPLOAD, true);
     curl_easy_setopt(d->m_handle, CURLOPT_INFILESIZE, 0);
 
     // Disable the Expect: 100 continue header
@@ -917,7 +917,7 @@ void ResourceHandleManager::setupPUT(ResourceHandle* job, struct curl_slist** he
 void ResourceHandleManager::setupPOST(ResourceHandle* job, struct curl_slist** headers)
 {
     ResourceHandleInternal* d = job->getInternal();
-    curl_easy_setopt(d->m_handle, CURLOPT_POST, TRUE);
+    curl_easy_setopt(d->m_handle, CURLOPT_POST, true);
     curl_easy_setopt(d->m_handle, CURLOPT_POSTFIELDSIZE, 0);
 
     size_t numElements = getFormElementsCount(job);
@@ -1205,13 +1205,13 @@ void ResourceHandleManager::initializeHandle(ResourceHandle* job)
 
     String method = job->firstRequest().httpMethod();
     if ("GET" == method)
-        curl_easy_setopt(d->m_handle, CURLOPT_HTTPGET, TRUE);
+        curl_easy_setopt(d->m_handle, CURLOPT_HTTPGET, true);
     else if ("POST" == method)
         setupPOST(job, &headers);
     else if ("PUT" == method)
         setupPUT(job, &headers);
     else if ("HEAD" == method)
-        curl_easy_setopt(d->m_handle, CURLOPT_NOBODY, TRUE);
+        curl_easy_setopt(d->m_handle, CURLOPT_NOBODY, true);
     else {
         curl_easy_setopt(d->m_handle, CURLOPT_CUSTOMREQUEST, method.ascii().data());
         setupPUT(job, &headers);

--- a/Source/WebCore/platform/text/TextCodecICU.cpp
+++ b/Source/WebCore/platform/text/TextCodecICU.cpp
@@ -308,7 +308,7 @@ void TextCodecICU::createICUConverter() const
     m_converterICU = ucnv_open(m_canonicalConverterName, &err);
     ASSERT(U_SUCCESS(err));
     if (m_converterICU)
-        ucnv_setFallback(m_converterICU, TRUE);
+        ucnv_setFallback(m_converterICU, true);
 }
 
 int TextCodecICU::decodeToBuffer(UChar* target, UChar* targetLimit, const char*& source, const char* sourceLimit, int32_t* offsets, bool flush, UErrorCode& err)

--- a/Source/WebCore/platform/text/icu/UTextProvider.h
+++ b/Source/WebCore/platform/text/icu/UTextProvider.h
@@ -80,12 +80,12 @@ inline bool uTextAccessInChunkOrOutOfRange(UText* text, int64_t nativeIndex, int
             // Ensure chunk offset is well formed if computed offset exceeds int32_t range.
             ASSERT(offset < std::numeric_limits<int32_t>::max());
             text->chunkOffset = offset < std::numeric_limits<int32_t>::max() ? static_cast<int32_t>(offset) : 0;
-            isAccessible = TRUE;
+            isAccessible = true;
             return true;
         }
         if (nativeIndex >= nativeLength && text->chunkNativeLimit == nativeLength) {
             text->chunkOffset = text->chunkLength;
-            isAccessible = FALSE;
+            isAccessible = false;
             return true;
         }
     } else {
@@ -94,12 +94,12 @@ inline bool uTextAccessInChunkOrOutOfRange(UText* text, int64_t nativeIndex, int
             // Ensure chunk offset is well formed if computed offset exceeds int32_t range.
             ASSERT(offset < std::numeric_limits<int32_t>::max());
             text->chunkOffset = offset < std::numeric_limits<int32_t>::max() ? static_cast<int32_t>(offset) : 0;
-            isAccessible = TRUE;
+            isAccessible = true;
             return true;
         }
         if (nativeIndex <= 0 && !text->chunkNativeStart) {
             text->chunkOffset = 0;
-            isAccessible = FALSE;
+            isAccessible = false;
             return true;
         }
     }

--- a/Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp
+++ b/Source/WebCore/platform/text/icu/UTextProviderLatin1.cpp
@@ -100,23 +100,23 @@ static UBool uTextLatin1Access(UText* uText, int64_t index, UBool forward)
         if (index < uText->chunkNativeLimit && index >= uText->chunkNativeStart) {
             // Already inside the buffer. Set the new offset.
             uText->chunkOffset = static_cast<int32_t>(index - uText->chunkNativeStart);
-            return TRUE;
+            return true;
         }
         if (index >= length && uText->chunkNativeLimit == length) {
             // Off the end of the buffer, but we can't get it.
             uText->chunkOffset = uText->chunkLength;
-            return FALSE;
+            return false;
         }
     } else {
         if (index <= uText->chunkNativeLimit && index > uText->chunkNativeStart) {
             // Already inside the buffer. Set the new offset.
             uText->chunkOffset = static_cast<int32_t>(index - uText->chunkNativeStart);
-            return TRUE;
+            return true;
         }
         if (!index && !uText->chunkNativeStart) {
             // Already at the beginning; can't go any farther.
             uText->chunkOffset = 0;
-            return FALSE;
+            return false;
         }
     }
     
@@ -144,7 +144,7 @@ static UBool uTextLatin1Access(UText* uText, int64_t index, UBool forward)
 
     uText->nativeIndexingLimit = uText->chunkLength;
 
-    return TRUE;
+    return true;
 }
 
 static int32_t uTextLatin1Extract(UText* uText, int64_t start, int64_t limit, UChar* dest, int32_t destCapacity, UErrorCode* status)
@@ -336,7 +336,7 @@ static int64_t uTextLatin1ContextAwareNativeLength(UText* text)
 static UBool uTextLatin1ContextAwareAccess(UText* text, int64_t nativeIndex, UBool forward)
 {
     if (!text->context)
-        return FALSE;
+        return false;
     int64_t nativeLength = uTextLatin1ContextAwareNativeLength(text);
     UBool isAccessible;
     if (uTextAccessInChunkOrOutOfRange(text, nativeIndex, nativeLength, forward, isAccessible))
@@ -356,7 +356,7 @@ static UBool uTextLatin1ContextAwareAccess(UText* text, int64_t nativeIndex, UBo
         ASSERT(newContext == UTextProviderContext::PriorContext);
         textLatin1ContextAwareSwitchToPriorContext(text, nativeIndex, nativeLength, forward);
     }
-    return TRUE;
+    return true;
 }
 
 static int32_t uTextLatin1ContextAwareExtract(UText*, int64_t, int64_t, UChar*, int32_t, UErrorCode* errorCode)

--- a/Source/WebCore/platform/text/icu/UTextProviderUTF16.cpp
+++ b/Source/WebCore/platform/text/icu/UTextProviderUTF16.cpp
@@ -125,7 +125,7 @@ static inline int64_t uTextUTF16ContextAwareNativeLength(UText* text)
 static UBool uTextUTF16ContextAwareAccess(UText* text, int64_t nativeIndex, UBool forward)
 {
     if (!text->context)
-        return FALSE;
+        return false;
     int64_t nativeLength = uTextUTF16ContextAwareNativeLength(text);
     UBool isAccessible;
     if (uTextAccessInChunkOrOutOfRange(text, nativeIndex, nativeLength, forward, isAccessible))
@@ -145,7 +145,7 @@ static UBool uTextUTF16ContextAwareAccess(UText* text, int64_t nativeIndex, UBoo
         ASSERT(newContext == UTextProviderContext::PriorContext);
         textUTF16ContextAwareSwitchToPriorContext(text, nativeIndex, nativeLength, forward);
     }
-    return TRUE;
+    return true;
 }
 
 static int32_t uTextUTF16ContextAwareExtract(UText*, int64_t, int64_t, UChar*, int32_t, UErrorCode* errorCode)


### PR DESCRIPTION
Because TRUE/FALSE causes compile errors as not defined, I propose change simply UPPERCASE to lowercase.