### PR TITLE
Add #include <stdio.h> for declaration of vasprintf()

### DIFF
--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -33,6 +33,7 @@
 #include <wtf/MathExtras.h>
 #include <wtf/text/CString.h>
 #include <wtf/unicode/CharacterNames.h>
+#include <stdio.h> // vasprintf()
 
 #if USE(CF)
 #include <wtf/RetainPtr.h>


### PR DESCRIPTION
Without this include, compiler throws error, that vasprintf() is not declared. Adding this commit fixes this error.