### PR TITLE
Temporarily solution for include

### DIFF
--- a/Source/WebCore/css/makegrammar.pl
+++ b/Source/WebCore/css/makegrammar.pl
@@ -93,3 +93,6 @@ close HEADER;
 unlink("$fileBase.cpp.h");
 unlink("$fileBase.hpp");
 
+# This is a temporarily solution
+# In unknown place script generates in include extension hpp instead h what causes compiler error
+system("sed \"s\\hpp\\h\\g\" -i $fileBase.cpp"); # remove after find good solution


### PR DESCRIPTION
This is a temporarily solution
From unknown reason script generates in include extension hpp instead h what causes compiler error.
For example, when file CSSGrammar.cpp and CSSGrammar.h are generated, in line 160 of CSSGrammar.cpp is put:
```
#include "CSSGrammar.hpp"
```
it should be
```
#include "CSSGrammar.h"
```
This behavior causes compilation error because absention of CSSGrammar.hpp.
I recommend remove this solution, when script bug will be resolved.
